### PR TITLE
Ignore data utf8 uri

### DIFF
--- a/lib/css-parser.js
+++ b/lib/css-parser.js
@@ -1,4 +1,4 @@
-var embeddedRegexp = /^data:(.*?),(.*?)/;
+var embeddedRegexp = /^data:(.*?)[,;](.*?)/;
 var commentRegexp = /\/\*([\s\S]*?)\*\//g;
 var urlsRegexp = /(?:@import\s+)?url\s*\(\s*(("(.*?)")|('(.*?)')|(.*?))\s*\)|(?:@import\s+)(("(.*?)")|('(.*?)')|(.*?))[\s;]/ig;
 

--- a/test/css-parser-test.js
+++ b/test/css-parser-test.js
@@ -242,5 +242,14 @@ describe('Parse css urls', function(){
 			urls.should.be.instanceof(Array);
 			urls.should.have.length(0);
 		})
+
+    it('should ignore data uri ("data:image/svg+xml;utf-8")', function() {
+    	var text = 'img.grayscale { \
+    		filter: url("data:image/svg+xml;utf-8"); \
+    	}';
+    	var urls = parseCssUrls(text);
+    	urls.should.be.instanceof(Array);
+    	urls.should.have.length(0);
+    })
 	});
 });


### PR DESCRIPTION
Hello,

I discovered that the library is not ignoring `data:image/svg+xml;utf-8"`

I found it parsing the following stylesheet:
https://gist.github.com/Kikobeats/0d295b07c88c2e25ca1c2f91cc3824c5

