### PR TITLE
Lock esquery to 1.1.x to prevent failing tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "devDependencies": {
     "coveralls": "^3.0.0",
     "eslint": "^4.15.0",
+    "esquery": "1.1.x",
     "istanbul": "^0.4.5",
     "mocha": "^5.0.0",
     "should": "^13.0.0"


### PR DESCRIPTION
closes #44 