### PR TITLE
Remove esquery as they fixed eslint issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "devDependencies": {
     "coveralls": "^3.0.0",
     "eslint": "^4.15.0",
-    "esquery": "1.1.x",
     "istanbul": "^0.4.5",
     "mocha": "^5.0.0",
     "should": "^13.0.0"


### PR DESCRIPTION
esquery removes BC break changes in 1.2.1.

See https://github.com/estools/esquery/pull/96

Closes #46 